### PR TITLE
Added plugin opening bracket around usage code in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ import { defineConfig } from "vite"
 import { watch } from "vite-plugin-watch"
 
 export default defineConfig({
+  plugins: [ 
     watch({
       pattern: "app/{Data,Enums}/**/*.php",
       command: "php artisan typescript:transform",


### PR DESCRIPTION
This adds the plugin array wrapper around the `watch` function in the usage section of the readme.

Sorry for the small PR but I'd noticed the ending bracket is present for the plugins array but the opening bracket is missing.