### PR TITLE
Fix windows path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ export const watch = (config: {
 
       const patterns = Array.of(options.pattern).flat()
       const shouldRun = patterns.find((pattern) =>
-        minimatch(file, path.resolve(server.config.root, pattern))
+        minimatch(file, path.resolve(server.config.root, pattern).replaceAll("\\", "/"))
       )
 
       if (shouldRun) {


### PR DESCRIPTION
vite version: v4.2.1
vite-plugin-watch: v0.1.1

When changing files on Windows 11, the command won't be triggered as the path doesn't match.