### PR TITLE
Add exports types field

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/vite-plugin-watch.js",
       "require": "./dist/vite-plugin-watch.umd.cjs"
     }


### PR DESCRIPTION
When configuring `tsconfig` with `moduleresolution: bundler` on TypeScript 5, types from `vite-plugin-watch` can't be accessible, requiring `types` to be set in `exports` to use them.