### PR TITLE
fix es module scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-watch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-watch",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "minimatch": "^5.1.1"
       },
@@ -24,6 +24,9 @@
         "typescript": "^4.9.4",
         "vite": "^4.0.1",
         "vite-plugin-eslint": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=10.6.0"
       }
     },
     "node_modules/@esbuild/android-arm": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { PluginOption } from "vite"
 import minimatch from "minimatch"
-const path = require("path")
-const { exec } = require("child_process")
+import path from "path"
+import { exec } from "child_process"
 
 export const watch = (config: {
   pattern: string | string[]


### PR DESCRIPTION
Changed the imports to fix this little typescript issue -> 

```
error when starting dev server:
ReferenceError: require is not defined in ES module scope, you can use import instead
```