### PR TITLE
Execute multiple commands in one watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ The paths of tracked files are configured as [glob patterns](<https://en.wikiped
 
 ## Plugin options
 
-| name    | type             | description                                 | default |
-| ------- | ---------------- | ------------------------------------------- | ------- |
-| pattern | string\|string[] | Tracked files paths                         |         |
-| command | string           | A command executed on file change           |         |
-| timeout | number           | Timeout between triggering the same command | 500     |
-| silent  | boolean          | Hide the output in the console              | false   |
-| onInit  | boolean          | Run the command on Vite start               | true    |
+| name    | type             | description                                              | default |
+| ------- | ---------------- | -------------------------------------------------------- | ------- |
+| pattern | string\|string[] | Tracked files paths                                      |         |
+| command | string\|string[] | One or multiple command(s) to be executed on file change |         |
+| timeout | number           | Timeout between triggering the same command              | 500     |
+| silent  | boolean          | Hide the output in the console                           | false   |
+| onInit  | boolean          | Run the command on Vite start                            | true    |
 
 ## Advanced Inertia
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export const watch = (config: {
 
   const execute = () => {
     [].concat(options.command).forEach(command => {
-      exec(options.command, (exception, output, error) => {
+      exec(command, (exception, output, error) => {
         if (!options.silent && output) console.log(output)
         if (!options.silent && error) console.error(error)
       })

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { exec } from "node:child_process"
 
 export const watch = (config: {
   pattern: string | string[]
-  command: string
+  command: string | string[]
   silent?: boolean
   timeout?: number
   onInit?: boolean
@@ -20,9 +20,11 @@ export const watch = (config: {
   let throttled = false
 
   const execute = () => {
-    exec(options.command, (exception, output, error) => {
-      if (!options.silent && output) console.log(output)
-      if (!options.silent && error) console.error(error)
+    [].concat(options.command).forEach(command => {
+      exec(options.command, (exception, output, error) => {
+        if (!options.silent && output) console.log(output)
+        if (!options.silent && error) console.error(error)
+      })
     })
   }
 


### PR DESCRIPTION
Allows array syntax to support multiple commands at once:

```
watch({
  pattern: "some/path/**/*.php",
  command: ["command 1", "command 2"],
}),
```