### PR TITLE
Add option to await child process to avoid race conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The paths of tracked files are configured as [glob patterns](<https://en.wikiped
 | timeout | number           | Timeout between triggering the same command              | 500     |
 | silent  | boolean          | Hide the output in the console                           | false   |
 | onInit  | boolean          | Run the command on Vite start                            | true    |
+| await   | boolean          | Await the completion of the command                      | false   |
 
 ## Advanced Inertia
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       fileName: `vite-plugin-watch`,
     },
     rollupOptions: {
-      external: ["node:child_process", "node:path"],
+      external: ["node:child_process", "node:path", "node:util"],
     },
   },
   plugins: [eslintPlugin()],


### PR DESCRIPTION
Found an issue with this plugin where occasionally, some of the outputs of these tasks were not yet available by the time the subsequent build step ran.

This seems to be a result of the way the child process is called. Vite will accept a promise as a return value and subsequently await the promise before proceeding. This update modifies the execute command to be async and await all of the child processes it creates. This is technically a breaking change as there may be some users that rely on the existing behaviour. For this reason, an `await` option has also been added so that this behaviour can be opted in to. I would consider making this the default at some point in the future however, as I think its what most users will want and expect.